### PR TITLE
Improve performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .pio
 cmake-build-debug
 CMakeListsPrivate.txt
+.pioenvs
+.piolibdeps

--- a/lib/com/com.hpp
+++ b/lib/com/com.hpp
@@ -25,6 +25,7 @@ class Com {
 private:
     SoftwareSerial * swSer;
     Stats * stats;
+    long lastStatsReportTime = 0;
     bool statsChanged;
 #if DEV_MODE == 1
     GWHomie * homie;
@@ -210,7 +211,8 @@ public:
         }
 
 #if DEV_MODE == 2
-        if (statsChanged) {
+        if (statsChanged && millis() - lastStatsReportTime > 300) {
+            lastStatsReportTime = millis();
             statsChanged = false;
             send(
                     utils::msgType::stats,

--- a/lib/com/com.hpp
+++ b/lib/com/com.hpp
@@ -74,7 +74,7 @@ private:
             Serial.printf("[com] Stats update from NOW node\n");
             stats->setNowSentMessagesSuccessful(doc.get<int>("success"));
             stats->setNowSentMessagesFailed(doc.get<int>("failed"));
-            stats->setNowSentMessagesReceived(doc.get<int>("received"));
+            stats->setNowMessagesReceived(doc.get<int>("received"));
 #endif // DEV_MODE == 1
 #if DEV_MODE == 2
         } else if (type == (uint8) utils::msgType::send_now_message) {
@@ -104,7 +104,7 @@ public:
             text.concat(" Failed=");
             text.concat(this->stats->getNowSentMessagesFailed());
             text.concat(" Received=");
-            text.concat(this->stats->getNowSentMessagesReceived());
+            text.concat(this->stats->getNowMessagesReceived());
             this->ws->textAll((char *) text.c_str());
         });
     }
@@ -221,7 +221,7 @@ public:
                     "failed",
                     stats->getNowSentMessagesFailed(),
                     "received",
-                    stats->getNowSentMessagesReceived()
+                    stats->getNowMessagesReceived()
             );
         }
 #endif

--- a/lib/com/com.hpp
+++ b/lib/com/com.hpp
@@ -72,9 +72,8 @@ private:
             ws->textAll("Message not delivered");
         } else if (type == utils::msgType::stats) {
             Serial.printf("[com] Stats update from NOW node\n");
-            stats->setNowSentMessagesSuccessful(doc.get<int>("success"));
-            stats->setNowSentMessagesFailed(doc.get<int>("failed"));
-            stats->setNowMessagesReceived(doc.get<int>("received"));
+            String data = doc.get<String>("data");
+            stats->unpackRemoteData(data);
 #endif // DEV_MODE == 1
 #if DEV_MODE == 2
         } else if (type == (uint8) utils::msgType::send_now_message) {
@@ -216,12 +215,8 @@ public:
             send(
                     utils::msgType::stats,
                     0,
-                    "success",
-                    stats->getNowSentMessagesSuccessful(),
-                    "failed",
-                    stats->getNowSentMessagesFailed(),
-                    "received",
-                    stats->getNowMessagesReceived()
+                    "data",
+                    stats->packRemoteData()
             );
         }
 #endif

--- a/lib/com/com.hpp
+++ b/lib/com/com.hpp
@@ -90,6 +90,18 @@ private:
         }
     }
 
+    void sendJson(JsonObject & json) {
+        String buf;
+        buf += '\n';
+        json.printTo(buf);
+        buf += '\n';
+
+        this->swSer->print(buf);
+
+        Serial.print("[com] Sending: ");
+        Serial.print(buf.substring(1));
+    }
+
 public:
 #if DEV_MODE == 1
     Com(Stats * stats, GWHomie * h, WebSocket * ws) {
@@ -152,13 +164,7 @@ public:
             json.set(name3, value3);
         }
 
-        this->swSer->print("\n");
-        json.printTo(*this->swSer);
-        this->swSer->print("\n");
-
-        Serial.print("[com] Sending: ");
-        json.printTo(Serial);
-        Serial.println();
+        sendJson(json);
     }
 
     void setup() {
@@ -197,13 +203,8 @@ public:
                 if (dataIndex.id) {
                     root["id"] = dataIndex.id;
                 }
-                this->swSer->println();
-                root.printTo(*this->swSer);
-                this->swSer->println();
 
-                Serial.print("[com] Sending: ");
-                root.printTo(Serial);
-                Serial.println();
+                sendJson(root);
 
                 Buffer::remove(0);
             }

--- a/lib/com/com.hpp
+++ b/lib/com/com.hpp
@@ -147,7 +147,7 @@ public:
 
     template <typename T1, typename T2, typename T3>
     void send(utils::msgType type, unsigned long id, String name1, T1 value1, String name2, T2 value2, String name3, T3 value3) {
-        StaticJsonBuffer<200> jsonBuffer;
+        StaticJsonBuffer<JSON_OBJECT_SIZE(6)> jsonBuffer;
         JsonObject& json = jsonBuffer.createObject();
 
         json.set("type", (int) type);
@@ -194,7 +194,7 @@ public:
         if (!Buffer::is_buffer_empty() && !this->swSer->available()) {
             Buffer::Index dataIndex = Buffer::get_index(0);
             if (dataIndex.type == utils::msgType::send_now_message) {
-                StaticJsonBuffer<300> jsonBuffer;
+                StaticJsonBuffer<JSON_OBJECT_SIZE(6)> jsonBuffer;
                 JsonObject& root = jsonBuffer.createObject();
                 root["type"] = (int) utils::msgType::send_now_message;
                 const String string = Buffer::get_data(0);

--- a/lib/now/now.hpp
+++ b/lib/now/now.hpp
@@ -32,7 +32,7 @@ static volatile IncomingNowMessage incomingBuffer[INCOMING_BUFFER_SIZE];
 // Now callback can not update class instance itself, so create global variables for stats to be synced with Stats instance
 int volatile now_sent_messages_successful = 0;
 int volatile now_sent_messages_failed = 0;
-int volatile now_sent_messages_received = 0;
+int volatile now_messages_received = 0;
 
 class Now {
 private:
@@ -114,17 +114,17 @@ public:
             }
         }
 
-        while (now_sent_messages_successful) {
-            this->stats->addNowSentMessagesSuccessful();
-            now_sent_messages_successful--;
+        if (now_sent_messages_successful) {
+            this->stats->addNowSentMessagesSuccessful(now_sent_messages_successful);
+            now_sent_messages_successful = 0;
         }
-        while (now_sent_messages_failed) {
-            this->stats->addNowSentMessagesFailed();
-            now_sent_messages_failed--;
+        if (now_sent_messages_failed) {
+            this->stats->addNowSentMessagesFailed(now_sent_messages_failed);
+            now_sent_messages_failed = 0;
         }
-        while (now_sent_messages_received) {
-            this->stats->addNowSentMessagesReceived();
-            now_sent_messages_received--;
+        if (now_messages_received) {
+            this->stats->addNowMessagesReceived(now_messages_received);
+            now_messages_received = 0;
         }
     }
 
@@ -155,7 +155,7 @@ public:
                     incomingBuffer[i].header.errorCount = 0;
                     memcpy((void *) incomingBuffer[i].message, (char *) data, len);
                     incomingBuffer[i].set = true;
-                    now_sent_messages_received++;
+                    now_messages_received++;
                     return;
                 }
             }

--- a/lib/now/now.hpp
+++ b/lib/now/now.hpp
@@ -142,9 +142,6 @@ public:
 
         // receiving now
         esp_now_register_recv_cb([](uint8_t *mac, uint8_t *data, uint8_t len) {
-            char raw[len + 1];
-            memcpy((void *) raw, (char *) data, len);
-            Serial.printf("[now] Incoming NOW message from %02X:%02X:%02X:%02X:%02X:%02X: %s\n", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5], raw);
             for (uint8 i=0; i < INCOMING_BUFFER_SIZE; i++) {
                 if (!incomingBuffer[i].set) {
                     memcpy((void *) incomingBuffer[i].header.mac, mac, 6);
@@ -160,7 +157,6 @@ public:
                 }
             }
 
-            Serial.println("[now] !!!!!!!!!!!!!!!! Received message, but previous message still in buffer");
         });
 
         // sent now cb

--- a/lib/now/now.hpp
+++ b/lib/now/now.hpp
@@ -40,6 +40,7 @@ volatile IncomingNowMessage incomingBuffer[INCOMING_BUFFER_SIZE];
 int volatile now_sent_messages_successful = 0;
 int volatile now_sent_messages_failed = 0;
 int volatile now_messages_received = 0;
+int volatile missed_incoming_now_messages = 0;
 int volatile incoming_buffer_free = INCOMING_BUFFER_SIZE;
 int volatile message_buffer_free = NOW_BUFFER_SIZE;
 
@@ -173,6 +174,10 @@ public:
             this->stats->addNowMessagesReceived(now_messages_received);
             now_messages_received = 0;
         }
+        if (missed_incoming_now_messages) {
+            this->stats->addMissedIncomingNowMessages(missed_incoming_now_messages);
+            missed_incoming_now_messages = 0;
+        }
         if (incoming_buffer_free != this->stats->getIncomingBufferFree()) {
             this->stats->setIncomingBufferFree(incoming_buffer_free);
         }
@@ -197,6 +202,7 @@ public:
         esp_now_register_recv_cb([](uint8_t *mac, uint8_t *data, uint8_t len) {
             if (incomingBuffer[incomingBufferFreeSlot].set) {
                 // No free slots for accepting incoming NOW message, discarding message
+                missed_incoming_now_messages++;
                 return;
             }
 

--- a/lib/now/now.hpp
+++ b/lib/now/now.hpp
@@ -78,7 +78,10 @@ public:
             // move incoming NOW message from `incomingBuffer` to `now_data_buffer`
             NowMessage msg;
             memcpy(& msg.buffer_data, (const void *) & incomingBuffer[incomingBufferFilledSlot].header, sizeof(NowMessageHeader));
-            msg.append((const char *) incomingBuffer[incomingBufferFilledSlot].message, msg.buffer_data.msgLen);
+            int added = msg.append((const char *) incomingBuffer[incomingBufferFilledSlot].message, msg.buffer_data.msgLen);
+            if (added == -1) {
+                break;
+            }
             incomingBuffer[incomingBufferFilledSlot].set = false;
 
             incomingBufferFilledSlot = (incomingBufferFilledSlot + (uint8) 1) % (uint8) INCOMING_BUFFER_SIZE;

--- a/lib/now/now.hpp
+++ b/lib/now/now.hpp
@@ -38,14 +38,11 @@ class Now {
 private:
     Com * com;
     Stats * stats;
-public:
-    Now(Com * c, Stats * stats) {
-        this->com = c;
-        this->com->addOnNowMessageSendListener(std::bind(&Now::send, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
-        this->stats = stats;
-    }
 
-    bool send(String mac, const char * msg, uint8 len, unsigned long id) {
+    /**
+     * Callback for NOW messages to be sent. Adds message to queue.
+     */
+    bool sendNowMessageOut(String mac, const char *msg, uint8 len, unsigned long id) {
         NowMessage nowMessage;
         if (!nowMessage.setMac(mac)) {
             return false;
@@ -55,7 +52,14 @@ public:
         nowMessage.buffer_data.time = millis();
         nowMessage.buffer_data.id = id;
         nowMessage.buffer_data.errorCount = 0;
+
         return nowMessage.append(msg, len) > -1;
+    }
+public:
+    Now(Com * c, Stats * stats) {
+        this->com = c;
+        this->com->addOnNowMessageSendListener(std::bind(&Now::sendNowMessageOut, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
+        this->stats = stats;
     }
 
     void loop() {

--- a/lib/now/now.hpp
+++ b/lib/now/now.hpp
@@ -85,8 +85,12 @@ public:
         }
 
         int pos = 0;
+        long loopStartTime = millis();
+        uint8 previousIncomingBufferFreeSlot = incomingBufferFreeSlot;
         while (true) {
-            yield();
+            if (previousIncomingBufferFreeSlot != incomingBufferFreeSlot || millis() - loopStartTime > 500) {
+                break;
+            }
             NowMessage msg(pos);
             if (!msg.isSaved()) {
                 break;

--- a/lib/now/now.hpp
+++ b/lib/now/now.hpp
@@ -13,7 +13,7 @@ extern "C" {
 #include "user_interface.h"
 }
 
-#define INCOMING_BUFFER_SIZE 10
+#define INCOMING_BUFFER_SIZE 20
 
 uint8_t gatewayMac[] = {0x30, 0x30, 0x30, 0x30, 0x30, 0x30};
 //uint8_t gatewayMac[] = {0x36, 0x33, 0x33, 0x33, 0x33, 0x33};

--- a/lib/screen/screen.hpp
+++ b/lib/screen/screen.hpp
@@ -91,7 +91,7 @@ public:
 
         // Messages count
         display.println("Msg (i/o):");
-        display.print(stats->getNowSentMessagesReceived());
+        display.print(stats->getNowMessagesReceived());
         display.print("/");
         display.println(stats->getNowSentMessagesSuccessful());
 

--- a/lib/screen/screen.hpp
+++ b/lib/screen/screen.hpp
@@ -95,6 +95,11 @@ public:
         display.print("/");
         display.println(stats->getNowSentMessagesSuccessful());
 
+        int buffer1FreeRelative = stats->getIncomingBufferSize() ? 100 * stats->getIncomingBufferFree() / stats->getIncomingBufferSize() : 0;
+        int buffer2FreeRelative = stats->getMessageBufferSize() ? 100 * stats->getMessageBufferFree() / stats->getMessageBufferSize() : 0;
+        display.drawLine(0, 46, 63 * buffer1FreeRelative / 100, 46, WHITE);
+        display.drawLine(0, 47, 63 * buffer2FreeRelative / 100, 47, WHITE);
+
         display.display();
     }
 };

--- a/lib/stats/stats.hpp
+++ b/lib/stats/stats.hpp
@@ -9,6 +9,7 @@ private:
         int volatile now_sent_messages_successful;
         int volatile now_sent_messages_failed;
         int volatile now_messages_received;
+        int volatile missed_incoming_now_messages;
         int volatile incoming_buffer_size;
         int volatile incoming_buffer_free;
         int volatile messages_buffer_size;
@@ -27,6 +28,7 @@ public:
         remoteData.now_sent_messages_successful = 0;
         remoteData.now_sent_messages_failed = 0;
         remoteData.now_messages_received = 0;
+        remoteData.missed_incoming_now_messages = 0;
         remoteData.incoming_buffer_size = 0;
         remoteData.incoming_buffer_free = 0;
         remoteData.messages_buffer_size = 0;
@@ -89,6 +91,11 @@ public:
         remoteData.now_messages_received += value;
     }
 
+    void addMissedIncomingNowMessages(int value = 1) {
+        stats_updated = true;
+        remoteData.missed_incoming_now_messages += value;
+    }
+
     void addIncomingBufferFree(int value = 1) {
         stats_updated = true;
         remoteData.incoming_buffer_free += value;
@@ -112,6 +119,11 @@ public:
     void setNowMessagesReceived(int value) {
         stats_updated = true;
         remoteData.now_messages_received = value;
+    }
+
+    void setMissedIncomingNowMessages(int value) {
+        stats_updated = true;
+        remoteData.missed_incoming_now_messages = value;
     }
 
     void setIncomingBufferSize(int value) {
@@ -144,6 +156,10 @@ public:
 
     int getNowMessagesReceived() {
         return remoteData.now_messages_received;
+    }
+
+    int getMissedIncomingNowMessages() {
+        return remoteData.missed_incoming_now_messages;
     }
 
     int getIncomingBufferSize() {

--- a/lib/stats/stats.hpp
+++ b/lib/stats/stats.hpp
@@ -9,6 +9,10 @@ private:
         int volatile now_sent_messages_successful;
         int volatile now_sent_messages_failed;
         int volatile now_messages_received;
+        int volatile incoming_buffer_size;
+        int volatile incoming_buffer_free;
+        int volatile messages_buffer_size;
+        int volatile messages_buffer_free;
     } remoteData;
 
     struct {
@@ -23,6 +27,10 @@ public:
         remoteData.now_sent_messages_successful = 0;
         remoteData.now_sent_messages_failed = 0;
         remoteData.now_messages_received = 0;
+        remoteData.incoming_buffer_size = 0;
+        remoteData.incoming_buffer_free = 0;
+        remoteData.messages_buffer_size = 0;
+        remoteData.messages_buffer_free = 0;
 
         stats_updated = true;
 
@@ -81,6 +89,16 @@ public:
         remoteData.now_messages_received += value;
     }
 
+    void addIncomingBufferFree(int value = 1) {
+        stats_updated = true;
+        remoteData.incoming_buffer_free += value;
+    }
+
+    void addMessageBufferFree(int value = 1) {
+        stats_updated = true;
+        remoteData.messages_buffer_free += value;
+    }
+
     void setNowSentMessagesSuccessful(int value) {
         stats_updated = true;
         remoteData.now_sent_messages_successful = value;
@@ -96,6 +114,26 @@ public:
         remoteData.now_messages_received = value;
     }
 
+    void setIncomingBufferSize(int value) {
+        stats_updated = true;
+        remoteData.incoming_buffer_size = value;
+    }
+
+    void setIncomingBufferFree(int value) {
+        stats_updated = true;
+        remoteData.incoming_buffer_free = value;
+    }
+
+    void setMessageBufferSize(int value) {
+        stats_updated = true;
+        remoteData.messages_buffer_size = value;
+    }
+
+    void setMessageBufferFree(int value) {
+        stats_updated = true;
+        remoteData.messages_buffer_free = value;
+    }
+
     int getNowSentMessagesSuccessful() {
         return remoteData.now_sent_messages_successful;
     }
@@ -106,6 +144,22 @@ public:
 
     int getNowMessagesReceived() {
         return remoteData.now_messages_received;
+    }
+
+    int getIncomingBufferSize() {
+        return remoteData.incoming_buffer_size;
+    }
+
+    int getIncomingBufferFree() {
+        return remoteData.incoming_buffer_free;
+    }
+
+    int getMessageBufferSize() {
+        return remoteData.messages_buffer_size;
+    }
+
+    int getMessageBufferFree() {
+        return remoteData.messages_buffer_free;
     }
 };
 

--- a/lib/stats/stats.hpp
+++ b/lib/stats/stats.hpp
@@ -5,7 +5,7 @@ class Stats {
 private:
     int volatile now_sent_messages_successful;
     int volatile now_sent_messages_failed;
-    int volatile now_sent_messages_received;
+    int volatile now_messages_received;
 
     bool stats_updated;
 
@@ -15,7 +15,7 @@ public:
     Stats() {
         now_sent_messages_successful = 0;
         now_sent_messages_failed = 0;
-        now_sent_messages_received = 0;
+        now_messages_received = 0;
 
         stats_updated = true;
 
@@ -36,19 +36,19 @@ public:
         onStatsChangeCallbackVector.push_back(cb);
     }
 
-    void addNowSentMessagesSuccessful() {
+    void addNowSentMessagesSuccessful(int value = 1) {
         stats_updated = true;
-        now_sent_messages_successful += 1;
+        now_sent_messages_successful += value;
     }
 
-    void addNowSentMessagesFailed() {
+    void addNowSentMessagesFailed(int value = 1) {
         stats_updated = true;
-        now_sent_messages_failed += 1;
+        now_sent_messages_failed += value;
     }
 
-    void addNowSentMessagesReceived() {
+    void addNowMessagesReceived(int value = 1) {
         stats_updated = true;
-        now_sent_messages_received += 1;
+        now_messages_received += value;
     }
 
     void setNowSentMessagesSuccessful(int value) {
@@ -61,9 +61,9 @@ public:
         now_sent_messages_failed = value;
     }
 
-    void setNowSentMessagesReceived(int value) {
+    void setNowMessagesReceived(int value) {
         stats_updated = true;
-        now_sent_messages_received = value;
+        now_messages_received = value;
     }
 
     int getNowSentMessagesSuccessful() {
@@ -74,8 +74,8 @@ public:
         return now_sent_messages_failed;
     }
 
-    int getNowSentMessagesReceived() {
-        return now_sent_messages_received;
+    int getNowMessagesReceived() {
+        return now_messages_received;
     }
 };
 

--- a/lib/stats/stats.hpp
+++ b/lib/stats/stats.hpp
@@ -1,11 +1,18 @@
 #ifndef STATS_INIT_H
 #define STATS_INIT_H
 
+#include <Base64.h>
+
 class Stats {
 private:
-    int volatile now_sent_messages_successful;
-    int volatile now_sent_messages_failed;
-    int volatile now_messages_received;
+    struct {
+        int volatile now_sent_messages_successful;
+        int volatile now_sent_messages_failed;
+        int volatile now_messages_received;
+    } remoteData;
+
+    struct {
+    } localData;
 
     bool stats_updated;
 
@@ -13,9 +20,9 @@ private:
     std::vector<onStatsChangeCallback> onStatsChangeCallbackVector;
 public:
     Stats() {
-        now_sent_messages_successful = 0;
-        now_sent_messages_failed = 0;
-        now_messages_received = 0;
+        remoteData.now_sent_messages_successful = 0;
+        remoteData.now_sent_messages_failed = 0;
+        remoteData.now_messages_received = 0;
 
         stats_updated = true;
 
@@ -32,50 +39,73 @@ public:
         }
     }
 
+    String packRemoteData() {
+        char data[sizeof(remoteData)];
+        memcpy(data, &remoteData, sizeof(remoteData));
+        int base64length = Base64.encodedLength(sizeof(remoteData));
+        char base64[base64length];
+        Base64.encode(base64, data, sizeof(remoteData));
+
+        return String(base64);
+    }
+
+    void unpackRemoteData(String base64Str) {
+        int base64StrLen = base64Str.length();
+
+        int decodedLen = Base64.decodedLength((char *) base64Str.c_str(), base64StrLen);
+
+        char decodedString[decodedLen];
+        Base64.decode(decodedString, (char *) base64Str.c_str(), base64StrLen);
+
+        memcpy(&remoteData, decodedString, sizeof(remoteData));
+
+        stats_updated = true;
+    }
+
     void addChangeCallback(onStatsChangeCallback cb) {
         onStatsChangeCallbackVector.push_back(cb);
     }
 
     void addNowSentMessagesSuccessful(int value = 1) {
         stats_updated = true;
-        now_sent_messages_successful += value;
+        remoteData.now_sent_messages_successful += value;
     }
 
     void addNowSentMessagesFailed(int value = 1) {
         stats_updated = true;
-        now_sent_messages_failed += value;
+        remoteData.now_sent_messages_failed += value;
     }
 
     void addNowMessagesReceived(int value = 1) {
         stats_updated = true;
-        now_messages_received += value;
+        remoteData.now_messages_received += value;
     }
 
     void setNowSentMessagesSuccessful(int value) {
         stats_updated = true;
-        now_sent_messages_successful = value;
+        remoteData.now_sent_messages_successful = value;
     }
 
     void setNowSentMessagesFailed(int value) {
         stats_updated = true;
-        now_sent_messages_failed = value;
+        remoteData.now_sent_messages_failed = value;
     }
 
     void setNowMessagesReceived(int value) {
         stats_updated = true;
-        now_messages_received = value;
+        remoteData.now_messages_received = value;
     }
 
     int getNowSentMessagesSuccessful() {
-        return now_sent_messages_successful;
+        return remoteData.now_sent_messages_successful;
     }
 
     int getNowSentMessagesFailed() {
-        return now_sent_messages_failed;
+        return remoteData.now_sent_messages_failed;
     }
 
     int getNowMessagesReceived() {
-        return now_messages_received;
+        return remoteData.now_messages_received;
     }
 };
 


### PR DESCRIPTION
This PR improved receiving NOW messages throughput. And added some additional stats about buffers state. OLED screen hows now buffers states as 2 progressbar lines at the bottom of the screen.

---

NOW node that sends and receives NOW messages have 2 buffers:
- volatile buffer for 20 NOW messages regardless of message length, this is only for receiving messages
- non-volatile buffer of 20kb that can hold 74-1176 messages, depending on message payload side that can be up to 250 bytes, this buffer contains also outgoing messages and success/failure responses. (for this test, there were no outgoing messages)

On incoming NOW message, message is stored to volatile buffer, if there is no free slots for message, then it's discarded.

NOW node has first priority to free volatile buffer by moving incoming message to non-volatile buffer. If there is no free space in non-volatile buffer, then message is kept in volatile buffer until space is freed from non-volatile buffer.

Now node frees non-volatile buffer by sending incoming messages over serial to be published in MQTT.

## Incoming message test

Made simple test that would send NOW messages with payload about 27 characters long to NOW gateway for about 30 seconds with 50 milliseconds interval, then pause for 60 seconds (allowing to free all buffers) and start new test circle with about 20% reduced interval. Additionally made test with 100ms interval.

This test is meant to how much messages NOW gateway can receive until it's buffer gets filled and starts dropping messages. Sent messages was received with simple node.js app over MQTT that checked messages sequence number and if detected dropped message, then stopped test. All messages were received in same order as sent out.

| Message interval | Messages received until first dropped message | About time since first message to first dropped message |
| - | - | - |
| 100ms | ~3700 | 6m10s |
| 50ms | 816 | 41s |
| 40ms | 707 | 28s |
| 32ms | 638 | 20s |
| 25ms | 588 | 15s |
| 20ms | 557 | 11s |
| 16ms | 542 | 9s |
| 12ms | 525 | 6s |
| 9ms | 515 | 5s |
| 7ms | 246 | 2s |
| 5ms | 42 | 0.2s |

Based on test message length, non-volatile buffer should be able to hold about 250 test messages. Two last test results indicates that first message that was dropped was because of volatile buffer was not emptied to non-volatile buffer fast enough although there was free space for messages in non-volatile buffer. For other tests, first message was dropped when non-volatile buffer and volatile buffer got full.

Sending messages every 110ms kept buffers empty all the time, this mean for my test I can constantly send about 9.9 messages per seconds for long duration, if sending 10 messages per second, then it took over 6 minutes until buffers got filled.

Volatile buffer with space for 20 messages means that NOW gateway can receive 20 messages at one time without delay between messages, then it needs some time to move messages to non-volatile buffer and is ready to accept new messages.

Moving 20 messages from volatile buffer to non-volatile buffer takes about 0.5 seconds.

Moving full non-volatile buffer over serial about 50 seconds.

Software serial between ESP8266 nodes runs at 9600 bits/second without any data corruption, increasing speed to 19200 bits/second introduces some data corruption. At the moment I think performance is good, maybe introduce additional software serial connections between ESP-s to increase overall throughput.

---

## EDIT

**Made additional test with 250 byte payload, then I could send constantly messages with 80ms interval or 12.5 messages per seconds without filling buffers. Also freeing all full buffers took about 7 seconds instead of 50 seconds. Did not expect better performance, so this topic need more investigation.**
Ok, JSON serialization was done twice, removed that and allocation less memory for creating JSON object. Now i'm getting same message throughput (80ms interval or 12.5 messages per seconds) with 250 bytes messages and 1 byte messages. I think JSON serialization takes lot of time.